### PR TITLE
Update entity.js

### DIFF
--- a/server/modules/live/entity.js
+++ b/server/modules/live/entity.js
@@ -1989,10 +1989,10 @@ class Entity extends EventEmitter {
         // Reset acceleration
         this.accel.null();
         // Apply motion
-        this.stepRemaining = 1;
-        if (Config.SPACE_PHYSICS) this.stepRemaining = 2;
         this.x += (this.stepRemaining * this.velocity.x) / Config.runSpeed;
         this.y += (this.stepRemaining * this.velocity.y) / Config.runSpeed;
+        this.stepRemaining = 1;
+        if (Config.SPACE_PHYSICS) this.stepRemaining = 2;
     }
     friction() {
         var motion = this.velocity.length,


### PR DESCRIPTION


This bug is a very old one. It even exists in nepphhh/arrasio, so it is a mistake by neph. Players have noticed that sometimes, tanks and bullets dashes forward when they get hit. Let's test with modified eggs. Have their health buffed to 65535, regen nerfed to 0, density buffed to 65535, pushability set to 0 if it isn't already 0, ai('moveincircles') removed, and hits_own_type changed to 'never'. Buff the reload of generators by 10x. Then, set up the server and spawn a line of eggs, not too much or they will(unlikely) cause lags. Then, switch to a different team, and ram them, or shoot a bullet into them. Your tank/bullet will move notably faster, but only if they are still colliding with the eggs. That's because stepRemaining don't work properly. It is supposed to record the amount of early movements done to entity by advancedCollision(), and do the remaining movements later when the variable is reset. However, the "remaining movements" are done AFTER the stepRemaining variable is reset. Thus, they always do full movement while the advancedCollision() function still pushes the moving entity to where it would collide to other entities with a limit of 1.

Before the fix:
https://github.com/user-attachments/assets/88890024-5b4a-4a07-ab72-c962c8f9f6b8
After the fix:
https://github.com/user-attachments/assets/d6abd57c-5fae-460e-8b1d-099a519d0945

